### PR TITLE
Include storage and processing for AWS billing

### DIFF
--- a/analytics/aws-logstash.template
+++ b/analytics/aws-logstash.template
@@ -20,12 +20,14 @@ Metadata:
         LinuxDockerLogGroupName: LxDockerLog
         LinuxSysLogGroupName: LxSysLog
         LinuxAuthLogGroupName: LxAuthLog
+        BillingLogGroupName: BillingLog
         RawLogBucketName: Raw
         RawLogSns: RawBucketNotification
         AccessS3LogBucketName: AccessS3Log
         AccessS3LogSns: AccessS3LogBucketNotification
         AccessCfLogBucketName: AccessCfLog
         AccessCfLogSns: AccessCfLogBucketNotification
+        BillingLogSns: BillingNotification
         CwlPolicy: LinuxLogPolicy
       Outputs:
         CwlDockerParams: DockerCwlParams
@@ -89,6 +91,9 @@ Parameters:
   LinuxAuthLogGroupName:
     Description: Name of VPC traffic log group.
     Type: String
+  BillingLogGroupName:
+    Description: Name of VPC traffic log group.
+    Type: String    
   EsHost:
     Description: Hostname of Elasticsearch
     Type: String
@@ -110,6 +115,9 @@ Parameters:
   AccessCfLogSns:
     Description: Hostname of Elasticsearch
     Type: String
+  BillingLogSns:
+    Description: Hostname of Elasticsearch
+    Type: String    
   LogstashDocker:
     Description: Name of cluster. This is used for discovery.
     Type: String
@@ -277,6 +285,14 @@ Resources:
         - Arn
       Protocol: sqs
       TopicArn: !Ref AccessCfLogSns
+  BillingSubscription:
+    Type: 'AWS::SNS::Subscription'
+    Properties:
+      Endpoint: !GetAtt 
+        - LogQueue
+        - Arn
+      Protocol: sqs
+      TopicArn: !Ref BillingLogSns
   LogQueue:
     Type: 'AWS::SQS::Queue'
     Properties:
@@ -361,6 +377,7 @@ Resources:
             -e RAW_BUCKET=${RawLogBucketName} \
             -e S3_BUCKET=${AccessS3LogBucketName} \
             -e CF_BUCKET=${AccessCfLogBucketName} \
+            -e BILL_BUCKET=${BillingLogGroupName} \
             ${LogstashSqsDocker}
           docker run -t --rm ${ContainerAwsUtil} cfn-signal -e $? --stack ${AWS::StackName} --resource LogstashSqsAsg --region ${AWS::Region}
     UpdatePolicy:

--- a/analytics/logs-store.template
+++ b/analytics/logs-store.template
@@ -654,6 +654,69 @@ Resources:
                 - !Ref 'AWS::AccountId'
                 - ':role/'
                 - !Ref LogStreamRole
+  BillingLog:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      AccessControl: LogDeliveryWrite
+      LoggingConfiguration:
+        DestinationBucketName: !Ref AccessS3Log
+        LogFilePrefix: !Join 
+          - ''
+          - - !Ref 'AWS::StackName'
+            - '-Billing/'
+      VersioningConfiguration:
+        Status: Enabled
+      NotificationConfiguration:
+        TopicConfigurations:
+          - Topic: !Ref BillingNotification
+            Event: 's3:ObjectCreated:*'
+    DeletionPolicy: Retain
+  BillingLogPolicy:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref BillingLog
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action:
+              - 's3:GetBucketAcl'
+              - 's3:GetBucketPolicy'
+            Resource: !Sub 'arn:aws:s3:::${BillingLog}'
+            Principal: 
+              AWS:
+                - 'arn:aws:iam::386209384616:root'
+          - Effect: Allow
+            Action:
+              - 's3:PutObject'
+            Principal: 
+              AWS:
+                - 'arn:aws:iam::386209384616:root'
+            Resource: !Sub 'arn:aws:s3:::${BillingLog}/*'
+          - Effect: Deny
+            Action:
+              - 's3:DeleteObject'
+              - 's3:DeleteObjectVersion'            
+            Resource: !Sub 'arn:aws:s3:::${BillingLog}/*'
+            Principal: '*'  
+  BillingNotification:
+    Type: 'AWS::SNS::Topic'
+    Properties:
+      DisplayName: Billing
+  BillingNotificationPolicy:
+    Type: 'AWS::SNS::TopicPolicy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Sid: Statement1            
+            Effect: Allow
+            Principal:
+              AWS: '*'
+            Action:
+              - 'SNS:Publish'
+            Resource:
+              - !Ref BillingNotification
+      Topics:
+        - !Ref BillingNotification                         
   LinuxMemoryAndLogShiping:
     Type: "AWS::SSM::Document"
     Properties: 


### PR DESCRIPTION
Hi,

I would like to merge changes I've been working and extending on your template. It includes the appropriate resources and IAM permission for AWS to drop billings into this new bucket, and once if there's any items created in the bucket, it should trigger SNS, and with the aws-logstash.template SQS subscribing, it should be consumed by the logstash docker instance templated here, which I will create another pull request just to ensure the templates works on your side first before I merge in the logstash changes, for the reason it's in another repo by design and should be decoupled from the template and this pull request

Regards
imomou